### PR TITLE
Only use BERT classifier output

### DIFF
--- a/metal/mmtl/metal_model.py
+++ b/metal/mmtl/metal_model.py
@@ -104,7 +104,7 @@ class MetalModel(nn.Module):
             # Extra .module call is to get past DataParallel wrapper
             input_module = self.input_modules[task_name].module
             if input_module not in outputs:
-                output = input_module(input)
+                output = input_module(input, is_input=True)
                 outputs[input_module] = output
 
             middle_module = self.middle_modules[task_name].module

--- a/metal/mmtl/metal_model.py
+++ b/metal/mmtl/metal_model.py
@@ -114,6 +114,7 @@ class MetalModel(nn.Module):
 
             head_module = self.head_modules[task_name].module
             if head_module not in outputs:
+                outputs[middle_module]["data"] = outputs[middle_module]["data"][1]
                 output = head_module(outputs[middle_module])
                 outputs[head_module] = output
         return {t: outputs[self.head_modules[t].module] for t in task_names}

--- a/metal/mmtl/modules.py
+++ b/metal/mmtl/modules.py
@@ -16,6 +16,18 @@ class MetalModuleWrapper(nn.Module):
     def forward(self, X):
         # The object that is passed out must be different from the object that gets
         # passed in so that cached outputs from intermediate modules aren't mutated
-        X_out = {k: v for k, v in X.items()}
-        X_out["data"] = self.module(X["data"])
-        return X_out
+        if is_input:
+            half_width_of_sequence = X["data"].shape[1] / 2
+            if half_width_of_sequence % 2 != 0:
+                raise "Token input of length n must be of form n input ids and n segment ids"
+            half_width_of_sequence = int(half_width_of_sequence)
+            X_out = {k: v for k, v in X.items()}
+
+            input_ids = X["data"][:, :half_width_of_sequence]
+            token_type_ids = X["data"][:, half_width_of_sequence:]
+            X_out["data"] = self.module(input_ids=input_ids, token_type_ids=token_type_ids)
+            return X_out
+        else:
+            X_out = {k: v for k, v in X.items()}
+            X_out["data"] = self.module(X["data"])
+            return X_out


### PR DESCRIPTION
Change the MeTaL code so that the BERT model output is treated as a tuple and only the first "[CLS]" token's output is used in classification.

BERT model output reference: https://github.com/huggingface/pytorch-pretrained-BERT/blob/701bd59b8b161c5400dd22869b0df202adba4a39/pytorch_pretrained_bert/modeling.py#L741